### PR TITLE
Allows adding relations across datasets in adminview of a gloss

### DIFF
--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -170,6 +170,7 @@ class GlossRelationSearchForm(forms.Form):
 
 
 class GlossRelationForm(forms.Form):
+    dataset = forms.ModelChoiceField(label=_("Lexicon"), queryset=Dataset.objects.all(), empty_label=None)
     source = forms.CharField(widget=forms.HiddenInput())
     target = forms.CharField(label=_("Gloss"), widget=forms.TextInput(attrs={'class': 'glossrelation-autocomplete'}))
     try:

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -127,9 +127,16 @@ $(document).ready(function () {
     <script src="{% static "js/jquery-ui.min.js" %}"></script>
     <script>
       $( function() {
-        var availableTags = {{dataset_glosses|safe}};
         $( ".glossrelation-autocomplete" ).autocomplete({
-          source: availableTags
+          source: async function (request, response) {
+              const { term } = request
+              const selectedDataset = $( "select#id_dataset option:checked" ).val() || null;
+              if (selectedDataset === null) return []
+              const data = await $.get(`/dictionary/ajax/glossrelation-autocomplete/${selectedDataset}?q=${term}`)
+              return response(data)
+          },
+          minLength: 2,
+          delay: 300
         });
       });
     </script>

--- a/signbank/dictionary/templates/dictionary/gloss_detail_relations.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail_relations.html
@@ -17,6 +17,7 @@
             {% for tag in tag_list %}
             <span class="badge" style="float:inherit;">{{tag}}</span>
             {% endfor %}
+            <span class="dataset-{{gr.target.dataset.id}}-color label label-default">{{gr.target.dataset}}</span>
             <form class="update_glossrelation" method="POST" action="{% url 'dictionary:add_glossrelation' %}" style="display:none;float:right;" >{% csrf_token %}
                 <input type="hidden" name="delete" value="{{gr.id}}">
                 <button type="submit" class="btn btn-link" >
@@ -30,6 +31,7 @@
     <div class="update_glossrelation" style="display: none;">
         <form class="form-inline" method="POST" action="{% url 'dictionary:add_glossrelation' %}">{% csrf_token %}
             <input type="hidden" name="source" value="{{gloss.id}}">
+            {% bootstrap_field glossrelationform.dataset required=True %}
             {% bootstrap_field glossrelationform.target show_label=False %}
             {% bootstrap_field glossrelationform.tag %}
             <button class="btn btn-primary btn-sm" type="submit">{% blocktrans %}Add relation{% endblocktrans %}</button>
@@ -47,6 +49,7 @@
             {% for tag in tag_list %}
             <span class="badge" style="float:inherit;">{{tag}}</span>
             {% endfor %}
+            <span class="dataset-{{gr.source.dataset.id}}-color label label-default">{{gr.source.dataset}}</span>
         </li>
         {% empty %}
         <li class="list-group-item">{% blocktrans %}No reverse relations.{% endblocktrans %}</li>

--- a/signbank/dictionary/templates/dictionary/public_gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/public_gloss_detail.html
@@ -119,6 +119,7 @@
                                 {% for tag in tag_list %}
                                 <span class="badge" style="float:inherit;">{{tag}}</span>
                                 {% endfor %}
+                                <span class="dataset-{{gr.target.dataset.id}}-color label label-default">{{gr.target.dataset}}</span>
                             </li>
                             {% empty %}
                             <li class="list-group-item">{% blocktrans %}No relations.{% endblocktrans %}</li>
@@ -144,6 +145,7 @@
                                 {% for tag in tag_list %}
                                 <span class="badge" style="float:inherit;">{{tag}}</span>
                                 {% endfor %}
+                                <span class="dataset-{{gr.source.dataset.id}}-color label label-default">{{gr.source.dataset}}</span>
                             </li>
                             {% empty %}
                             <li class="list-group-item">{% blocktrans %}No reverse relations.{% endblocktrans %}</li>

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -26,6 +26,7 @@ from .forms import TagsAddForm, TagUpdateForm, TagDeleteForm, GlossRelationForm,
 from ..video.models import GlossVideo
 
 
+@login_required
 @permission_required('dictionary.change_gloss')
 def update_gloss(request, glossid):
     """View to update a gloss model from the jeditable jquery form
@@ -170,6 +171,8 @@ def update_gloss(request, glossid):
         return HttpResponseNotAllowed(['POST'])
 
 
+@login_required
+@permission_required('dictionary.change_gloss')
 def update_keywords(gloss, field, value, language_code_2char):
     """Update the keyword field for the selected language"""
 
@@ -195,6 +198,8 @@ def update_keywords(gloss, field, value, language_code_2char):
     return HttpResponse(value, content_type='text/plain')
 
 
+@login_required
+@permission_required('dictionary.change_gloss')
 def update_relation(gloss, field, value):
     """Update one of the relations for this gloss"""
 
@@ -242,6 +247,8 @@ def update_relation(gloss, field, value):
     return HttpResponse(newvalue, content_type='text/plain')
 
 
+@login_required
+@permission_required('dictionary.change_gloss')
 def update_relationtoforeignsign(gloss, field, value):
     """Update one of the relations for this gloss"""
 
@@ -282,6 +289,8 @@ def update_relationtoforeignsign(gloss, field, value):
     return HttpResponse(value, content_type='text/plain')
 
 
+@login_required
+@permission_required('dictionary.change_gloss')
 def gloss_from_identifier(value):
     """Given an id of the form idgloss (pk) return the
     relevant gloss or None if none is found"""
@@ -332,6 +341,8 @@ def gloss_from_identifier(value):
         return None
 
 
+@login_required
+@permission_required('dictionary.change_gloss')
 def add_relation(request):
     """Add a new relation instance"""
 
@@ -369,6 +380,8 @@ def add_relation(request):
     return HttpResponseRedirect('/')
 
 
+@login_required
+@permission_required('dictionary.change_gloss')
 def add_relationtoforeignsign(request):
     """Add a new relationtoforeignsign instance"""
 
@@ -405,6 +418,8 @@ def add_relationtoforeignsign(request):
     return HttpResponseRedirect('/')
 
 
+@login_required
+@permission_required('dictionary.change_gloss')
 def add_morphology_definition(request):
     if request.method == "POST":
         form = MorphologyForm(request.POST)
@@ -428,6 +443,8 @@ def add_morphology_definition(request):
     raise Http404(_('Incorrect request'))
 
 
+@login_required
+@permission_required('dictionary.change_gloss')
 def update_morphology_definition(gloss, field, value):
     """Update one of the relations for this gloss"""
 
@@ -473,6 +490,7 @@ def update_morphology_definition(gloss, field, value):
     return HttpResponse(newvalue, content_type='text/plain')
 
 
+@login_required
 @permission_required('dictionary.change_gloss')
 def add_tag(request, glossid):
     """View to add a tag to a gloss"""
@@ -646,6 +664,8 @@ def confirm_import_gloss_csv(request):
         return HttpResponseRedirect(reverse('dictionary:import_gloss_csv'))
 
 
+@login_required
+@permission_required('dictionary.change_gloss')
 def gloss_relation(request):
     """Processes Gloss Relations"""
     if request.method == "POST":
@@ -673,7 +693,8 @@ def gloss_relation(request):
                 msg = _("You do not have permissions to add relations to glosses of this lexicon.")
                 messages.error(request, msg)
                 raise PermissionDenied(msg)
-            target = get_object_or_404(Gloss, id=form.cleaned_data["target"])
+            dataset = form.cleaned_data["dataset"]
+            target = get_object_or_404(Gloss, dataset=dataset, idgloss=form.cleaned_data["target"])
             glossrelation = GlossRelation.objects.create(source=source, target=target)
             if form.cleaned_data["tag"]:
                 Tag.objects.add_tag(glossrelation, form.cleaned_data["tag"].name)

--- a/signbank/dictionary/urls.py
+++ b/signbank/dictionary/urls.py
@@ -79,6 +79,8 @@ urlpatterns = [
         adminviews.gloss_ajax_complete, name='gloss_complete'),
     path('ajax/searchresults/',
         adminviews.gloss_ajax_search_results, name='ajax_search_results'),
+    path('ajax/glossrelation-autocomplete/<int:dataset>',
+        adminviews.glossrelation_autocomplete, name='glossrelation_autocomplete'),
 
     # XML ecv (externally controlled vocabulary) export for ELAN
     path('ecv/<int:dataset_id>',


### PR DESCRIPTION
- Introduces a new ajax endpoint to get autocomplete suggestions
- Changes the way how relations are submitted, idgloss instead of name,
  which should confuse users less as the label used to change to value of id
- Shows label in public and admin gloss views