### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-django==3.2.15
+django==3.2.18
 django-tagging==0.5.0
-django-reversion==4.0.0
+django-reversion==4.0.2
 django-bootstrap3==21.1
 django-summernote==0.8.20.0
-django-modeltranslation==0.17.3
+django-modeltranslation==0.18.6
 django-registration==3.2
-django-contrib-comments==2.1.0
+django-contrib-comments==2.2.0
 django-guardian==2.4.0
-django-notifications-hq==1.6.0
+django-notifications-hq==1.8.3


### PR DESCRIPTION
django to 3.2.18, 3.2.19 requires changes to ClearableFileInput
django-modeltranslation to 0.18.6, 0.18.7 introduces python typing not in python3.6,
  library dropped python3.6 support officially in 0.18.2